### PR TITLE
Add web orders workflow and detail views

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,12 +14,42 @@
   position: sticky;
   top: 0;
   z-index: 10;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .brand {
   font-size: 1rem;
   font-weight: 600;
   color: #1b1b1f;
+}
+
+.app-bar-left {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.app-nav-link {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  color: #1f2937;
+  background: transparent;
+  font-weight: 500;
+}
+
+.app-nav-link.active {
+  background: rgba(10, 103, 198, 0.12);
+  color: #0a67c6;
+  font-weight: 600;
 }
 
 .app-bar-actions {
@@ -92,6 +122,28 @@
   border: 0.2rem solid rgba(0, 0, 0, 0.1);
   border-top-color: #0a67c6;
   animation: spin 0.9s linear infinite;
+}
+
+.loader-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.loader-overlay-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  font-weight: 600;
 }
 
 @keyframes spin {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,20 @@
 import { useCallback } from 'react'
-import { Link, Navigate, Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import {
+  Link,
+  Navigate,
+  NavLink,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom'
 import ProtectedRoute from './components/ProtectedRoute.jsx'
 import { useAuth } from './context/AuthContext.jsx'
 import LoginPage from './pages/Login.jsx'
 import SettingsPage from './pages/Settings.jsx'
+import OrdersFeed from './pages/orders/OrdersFeed.jsx'
+import OrderDetails from './pages/orders/OrderDetails.jsx'
 import './App.css'
 
 function AppLayout() {
@@ -18,12 +29,33 @@ function AppLayout() {
 
   const isSettingsRoute = location.pathname.startsWith('/settings')
 
+  const navItems = [
+    { to: '/orders', label: 'Orders' },
+    { to: '/settings', label: 'Settings' },
+  ]
+
   return (
     <div className="app-shell">
       <header className="app-bar">
-        <Link to="/settings" className="brand" aria-label="Jason's Liquor driver portal">
-          Jason&apos;s Liquor Drivers
-        </Link>
+        <div className="app-bar-left">
+          <Link to="/orders" className="brand" aria-label="Jason's Liquor driver portal">
+            Jason&apos;s Liquor Drivers
+          </Link>
+          <nav className="app-nav" aria-label="Primary">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  ['app-nav-link', isActive ? 'active' : ''].filter(Boolean).join(' ')
+                }
+                end={item.to === '/settings'}
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
         <div className="app-bar-actions">
           {isSettingsRoute ? (
             <div className="user-meta">
@@ -47,13 +79,15 @@ export default function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
-      <Route element={<ProtectedRoute />}>
-        <Route element={<AppLayout />}>
-          <Route index element={<Navigate to="/settings" replace />} />
-          <Route path="/settings" element={<SettingsPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route element={<AppLayout />}>
+            <Route index element={<Navigate to="/orders" replace />} />
+            <Route path="/orders" element={<OrdersFeed />} />
+            <Route path="/orders/:status/:orderId" element={<OrderDetails />} />
+            <Route path="/settings" element={<SettingsPage />} />
+          </Route>
         </Route>
-      </Route>
-      <Route path="*" element={<Navigate to="/settings" replace />} />
+      <Route path="*" element={<Navigate to="/orders" replace />} />
     </Routes>
   )
 }

--- a/src/assets/placeholder-product.svg
+++ b/src/assets/placeholder-product.svg
@@ -1,0 +1,6 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" rx="12" fill="#E2E8F0" />
+  <path d="M54 18H66V28.5C66 30.9853 63.9853 33 61.5 33H58.5C56.0147 33 54 30.9853 54 28.5V18Z" fill="#1E3A8A"/>
+  <path d="M50 36H70L74 60V96C74 101.523 69.5228 106 64 106H56C50.4772 106 46 101.523 46 96V60L50 36Z" fill="#1D4ED8"/>
+  <path d="M52 48H68V56H52V48Z" fill="#DBEAFE"/>
+</svg>

--- a/src/components/LoaderOverlay.jsx
+++ b/src/components/LoaderOverlay.jsx
@@ -1,0 +1,14 @@
+export default function LoaderOverlay({ show, label = 'Loading' }) {
+  if (!show) {
+    return null
+  }
+
+  return (
+    <div className="loader-overlay" role="status" aria-live="assertive">
+      <div className="loader-overlay-card">
+        <div className="spinner" aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/orders/OrderDetails.jsx
+++ b/src/pages/orders/OrderDetails.jsx
@@ -1,0 +1,641 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import LoaderOverlay from '../../components/LoaderOverlay'
+import { useAuth } from '../../context/AuthContext'
+import fallbackImage from '../../assets/placeholder-product.svg'
+import {
+  fetchCardDetails,
+  fetchCardUses,
+  fetchOrderById,
+  sendArrivalMessage,
+  updateOrder,
+  updateOrderStatus,
+} from '../../services/orderService'
+import './Orders.css'
+
+const STATUS_VARIANTS = {
+  assigned: {
+    key: 'assigned',
+    statusLabel: 'Assigned',
+    pillClass: 'assigned',
+    primaryActionLabel: 'Tap to Accept',
+    primaryActionStatus: 'Accepted',
+    showMap: false,
+    showCardDetails: false,
+    includeCardUsage: true,
+    showMessageActions: false,
+    showFinalizeActions: false,
+  },
+  accepted: {
+    key: 'accepted',
+    statusLabel: 'Accepted',
+    pillClass: 'accepted',
+    primaryActionLabel: 'Tap to Start Delivery',
+    primaryActionStatus: 'In Progress',
+    showMap: true,
+    showCardDetails: false,
+    includeCardUsage: true,
+    showMessageActions: false,
+    showFinalizeActions: false,
+  },
+  progress: {
+    key: 'progress',
+    statusLabel: 'In Progress',
+    pillClass: 'progress',
+    primaryActionLabel: null,
+    primaryActionStatus: null,
+    showMap: true,
+    showCardDetails: true,
+    includeCardUsage: true,
+    showMessageActions: true,
+    showFinalizeActions: true,
+  },
+}
+
+function inferStatusKey(status) {
+  if (!status) {
+    return 'assigned'
+  }
+
+  const normalized = status.toLowerCase()
+
+  if (normalized === 'assigned') {
+    return 'assigned'
+  }
+
+  if (normalized === 'accepted') {
+    return 'accepted'
+  }
+
+  if (normalized === 'in progress') {
+    return 'progress'
+  }
+
+  return 'assigned'
+}
+
+function formatName(owner) {
+  if (!owner) {
+    return 'Customer'
+  }
+
+  return [owner?.name?.first, owner?.name?.last].filter(Boolean).join(' ') || 'Customer'
+}
+
+function formatDate(value) {
+  if (!value) {
+    return null
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value
+  }
+
+  return new Intl.DateTimeFormat('en-US').format(parsed)
+}
+
+function buildMapUrl(address) {
+  if (!address?.loc || address.loc.length < 2) {
+    return null
+  }
+
+  const [longitude, latitude] = address.loc
+
+  if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+    return null
+  }
+
+  const params = new URLSearchParams({
+    center: `${latitude},${longitude}`,
+    zoom: '16',
+    size: '600x350',
+    markers: `${latitude},${longitude},lightblue1`,
+  })
+
+  return `https://staticmap.openstreetmap.de/staticmap.php?${params.toString()}`
+}
+
+function formatAddress(address) {
+  if (!address) {
+    return 'No address on file'
+  }
+
+  const parts = []
+
+  if (address.apartment) {
+    parts.push(`Apartment #: ${address.apartment}`)
+  }
+
+  if (address.description) {
+    parts.push(address.description)
+  }
+
+  return parts.join(', ') || 'No address on file'
+}
+
+function getPhoneNumber(order, forRecipient) {
+  if (!order) {
+    return null
+  }
+
+  if (forRecipient) {
+    if (order.giftDelivery) {
+      return order.giftDeliveryDetails?.recipientPhone || order.owner?.phone || null
+    }
+
+    return order.owner?.phone || null
+  }
+
+  if (order.giftDelivery) {
+    return order.owner?.phone || null
+  }
+
+  return order.giftDeliveryDetails?.recipientPhone || order.owner?.phone || null
+}
+
+export default function OrderDetails() {
+  const { status: routeStatusKey, orderId } = useParams()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { token } = useAuth()
+
+  const initialOrder = location.state?.order ?? null
+
+  const [order, setOrder] = useState(initialOrder)
+  const [loading, setLoading] = useState(!initialOrder)
+  const [error, setError] = useState(null)
+  const [cardUses, setCardUses] = useState(null)
+  const [cardDetails, setCardDetails] = useState(null)
+  const [cardError, setCardError] = useState(null)
+  const [cardLoading, setCardLoading] = useState(false)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [messageLoading, setMessageLoading] = useState(false)
+  const [infoMessage, setInfoMessage] = useState(null)
+  const [imageStatus, setImageStatus] = useState(() => initialOrder?.products?.map(() => true) ?? [])
+
+  const resolvedStatusKey = useMemo(() => {
+    const normalized = routeStatusKey?.toLowerCase()
+    if (normalized && STATUS_VARIANTS[normalized]) {
+      return normalized
+    }
+
+    return inferStatusKey(order?.status)
+  }, [routeStatusKey, order?.status])
+
+  const variant = STATUS_VARIANTS[resolvedStatusKey] ?? STATUS_VARIANTS.assigned
+  const requiresCardInfo = variant.includeCardUsage || variant.showCardDetails
+
+  useEffect(() => {
+    let ignore = false
+
+    async function loadOrderDetails() {
+      if (!token || !orderId) {
+        return
+      }
+
+      setLoading(!initialOrder)
+      setError(null)
+
+      try {
+        const data = await fetchOrderById(orderId, token)
+        if (!ignore && data) {
+          setOrder(data)
+        }
+      } catch (err) {
+        if (!ignore) {
+          const message = err instanceof Error ? err.message : 'Unable to load order details.'
+          setError(message)
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadOrderDetails()
+
+    return () => {
+      ignore = true
+    }
+  }, [token, orderId, initialOrder])
+
+  useEffect(() => {
+    const count = order?.products?.length ?? 0
+    setImageStatus(Array.from({ length: count }, () => true))
+  }, [order?.products])
+
+  useEffect(() => {
+    let ignore = false
+
+    async function loadCardInformation() {
+      if (!requiresCardInfo || !order || !token) {
+        setCardUses(null)
+        setCardDetails(null)
+        setCardError(null)
+        return
+      }
+
+      const reference = order.creditCard || order.paymentMethod
+
+      if (!reference) {
+        setCardUses(null)
+        setCardDetails(null)
+        return
+      }
+
+      setCardLoading(true)
+      setCardError(null)
+
+      try {
+        if (variant.includeCardUsage) {
+          const uses = await fetchCardUses(reference, token)
+          if (!ignore) {
+            const parsedUses = typeof uses === 'number' ? uses : Number(uses) || 0
+            setCardUses(parsedUses)
+          }
+        }
+
+        if (variant.showCardDetails) {
+          const details = await fetchCardDetails(order.owner?.stripeID, reference, token)
+          if (!ignore) {
+            setCardDetails(details)
+          }
+        }
+      } catch (err) {
+        if (!ignore) {
+          const message = err instanceof Error ? err.message : 'Unable to load card details.'
+          setCardError(message)
+        }
+      } finally {
+        if (!ignore) {
+          setCardLoading(false)
+        }
+      }
+    }
+
+    loadCardInformation()
+
+    return () => {
+      ignore = true
+    }
+  }, [order, token, requiresCardInfo, variant.includeCardUsage, variant.showCardDetails])
+
+  const handleImageError = useCallback((index) => {
+    setImageStatus((prev) => {
+      if (!prev || prev.length === 0) {
+        return prev
+      }
+
+      const next = [...prev]
+      next[index] = false
+      return next
+    })
+  }, [])
+
+  const handlePrimaryAction = useCallback(async () => {
+    if (!order || !variant.primaryActionStatus || !token) {
+      return
+    }
+
+    setActionLoading(true)
+    setInfoMessage(null)
+
+    try {
+      await updateOrderStatus(order._id, variant.primaryActionStatus, token)
+      navigate('/orders', { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to update order.'
+      setInfoMessage({ type: 'error', text: message })
+    } finally {
+      setActionLoading(false)
+    }
+  }, [navigate, order, token, variant.primaryActionStatus])
+
+  const handleCancelOrder = useCallback(async () => {
+    if (!order || !token) {
+      return
+    }
+
+    const confirmCancel = window.confirm('Are you sure you want to cancel this order?')
+
+    if (!confirmCancel) {
+      return
+    }
+
+    setActionLoading(true)
+    setInfoMessage(null)
+
+    try {
+      await updateOrder(
+        {
+          _id: order._id,
+          status: 'Canceled',
+        },
+        token,
+      )
+      navigate('/orders', { replace: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to cancel order.'
+      setInfoMessage({ type: 'error', text: message })
+    } finally {
+      setActionLoading(false)
+    }
+  }, [navigate, order, token])
+
+  const handleSendMessage = useCallback(async () => {
+    if (!order || !token) {
+      return
+    }
+
+    const phone = getPhoneNumber(order, false)
+
+    if (!phone) {
+      setInfoMessage({ type: 'error', text: 'No phone number available for this order.' })
+      return
+    }
+
+    setMessageLoading(true)
+    setInfoMessage(null)
+
+    try {
+      await sendArrivalMessage(
+        {
+          phone,
+          orderId: order._id,
+        },
+        token,
+      )
+      setInfoMessage({ type: 'success', text: 'Arrival message sent successfully.' })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to send message.'
+      setInfoMessage({ type: 'error', text: message })
+    } finally {
+      setMessageLoading(false)
+    }
+  }, [order, token])
+
+  const handleCall = useCallback(() => {
+    if (!order) {
+      return
+    }
+
+    const phone = getPhoneNumber(order, true)
+
+    if (!phone) {
+      setInfoMessage({ type: 'error', text: 'No phone number available to call.' })
+      return
+    }
+
+    window.open(`tel:${phone}`)
+  }, [order])
+
+  const finalizePlaceholder = useCallback(() => {
+    setInfoMessage({
+      type: 'info',
+      text: 'This workflow requires identity verification and is available in the mobile app.',
+    })
+  }, [])
+
+  if (loading && !order) {
+    return (
+      <div className="screen">
+        <div className="spinner" aria-label="Loading order" />
+      </div>
+    )
+  }
+
+  if (!order) {
+    return (
+      <div className="screen">
+        <div className="form-error" role="alert">
+          {error || 'Order not found.'}
+        </div>
+      </div>
+    )
+  }
+
+  const mapUrl = variant.showMap ? buildMapUrl(order.address) : null
+  const overlayLabel = actionLoading
+    ? 'Updating order…'
+    : messageLoading
+    ? 'Sending message…'
+    : 'Working…'
+
+  return (
+    <div className="order-detail-screen">
+      <LoaderOverlay show={actionLoading || messageLoading} label={overlayLabel} />
+
+      <div className="order-detail-header">
+        <h1 className="order-detail-title">{formatName(order.owner)}</h1>
+        <div className="order-detail-meta">
+          <span className={`status-pill ${variant.pillClass}`}>{variant.statusLabel}</span>
+          <span>{formatAddress(order.address)}</span>
+        </div>
+      </div>
+
+      {infoMessage ? (
+        <p className={`notice ${infoMessage.type}`} role="status">
+          {infoMessage.text}
+        </p>
+      ) : null}
+
+      {error && order ? (
+        <div className="form-error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      {mapUrl ? (
+        <div className="map-preview">
+          <img src={mapUrl} alt="Delivery location map" loading="lazy" />
+        </div>
+      ) : null}
+
+      <section className="order-section-card">
+        <h2 className="section-heading">Order Summary</h2>
+        <div className="product-list">
+          {order.products?.map((product, index) => (
+            <div className="product-row" key={product._id ?? index}>
+              <div className="product-thumb">
+                <img
+                  src={imageStatus[index] && product.image ? product.image : fallbackImage}
+                  alt={product.Description || 'Product'}
+                  onError={() => handleImageError(index)}
+                />
+              </div>
+              <div className="product-info">
+                <span className="product-quantity">{order.qty?.[index] ?? 0}×</span>
+                <p className="product-name">
+                  {product.Description} {product.Size ? `- ${product.Size}` : ''}
+                </p>
+                {product.PriceB ? (
+                  <p className="product-price">${product.PriceB} ea</p>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="order-section-card">
+        <h2 className="section-heading">Delivery Notes / Apartment #</h2>
+        <p className="detail-note">{order.deliveryNote || 'N/A'}</p>
+      </section>
+
+      <section className="order-section-card">
+        <h2 className="section-heading">Delivery Details</h2>
+        <div className="detail-grid">
+          <span>
+            <strong>Customer:</strong> {formatName(order.owner)}
+          </span>
+          {variant.includeCardUsage ? (
+            <span>
+              <strong>Card Uses:</strong> {cardUses ?? '—'}{' '}
+              {cardUses === 1 ? <span className="badge">New Card</span> : null}
+            </span>
+          ) : null}
+          <span>
+            <strong>Orders Count:</strong> {order.owner?.orderCount ?? 0}{' '}
+            {order.owner?.orderCount === 1 ? <span className="badge">New Customer</span> : null}
+          </span>
+          <span>
+            <strong>Address:</strong> {formatAddress(order.address)}
+          </span>
+          {order.owner?.email ? (
+            <span>
+              <strong>Email:</strong> {order.owner.email}
+            </span>
+          ) : null}
+          {order.owner?.dob ? (
+            <span>
+              <strong>DOB:</strong> {formatDate(order.owner.dob)}
+            </span>
+          ) : null}
+          {order.owner?.phone ? (
+            <span>
+              <strong>Phone:</strong>{' '}
+              <a href={`tel:${order.owner.phone}`} rel="noreferrer">
+                {order.owner.phone}
+              </a>
+            </span>
+          ) : null}
+          <span>
+            <strong>Gift Delivery:</strong> {order.giftDelivery ? 'Yes' : 'No'}
+          </span>
+          {order.giftDelivery && order.giftDeliveryDetails ? (
+            <>
+              {order.giftDeliveryDetails.recipientName ? (
+                <span>
+                  <strong>Recipient Name:</strong> {order.giftDeliveryDetails.recipientName}
+                </span>
+              ) : null}
+              {order.giftDeliveryDetails.recipientPhone ? (
+                <span>
+                  <strong>Recipient Phone:</strong>{' '}
+                  <a href={`tel:${order.giftDeliveryDetails.recipientPhone}`} rel="noreferrer">
+                    {order.giftDeliveryDetails.recipientPhone}
+                  </a>
+                </span>
+              ) : null}
+              {order.giftDeliveryDetails.recipientBusinessName ? (
+                <span>
+                  <strong>Recipient Business:</strong> {order.giftDeliveryDetails.recipientBusinessName}
+                </span>
+              ) : null}
+              {order.giftDeliveryDetails.senderName ? (
+                <span>
+                  <strong>Sender Name:</strong> {order.giftDeliveryDetails.senderName}
+                </span>
+              ) : null}
+              {order.giftDeliveryDetails.senderPhone ? (
+                <span>
+                  <strong>Sender Phone:</strong>{' '}
+                  <a href={`tel:${order.giftDeliveryDetails.senderPhone}`} rel="noreferrer">
+                    {order.giftDeliveryDetails.senderPhone}
+                  </a>
+                </span>
+              ) : null}
+              {order.giftDeliveryDetails.senderDOB ? (
+                <span>
+                  <strong>Sender DOB:</strong> {formatDate(order.giftDeliveryDetails.senderDOB)}
+                </span>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+        {cardError ? (
+          <p className="notice error" role="alert">
+            {cardError}
+          </p>
+        ) : null}
+        {variant.showCardDetails && cardDetails ? (
+          <div className="detail-grid" style={{ marginTop: '0.75rem' }}>
+            <span>
+              <strong>Last 4:</strong> **** **** **** {cardDetails.last4 || '—'}{' '}
+              {order.fromWallet ? (
+                <span className="badge" style={{ background: '#2563eb' }}>
+                  {order.walletMethod}
+                </span>
+              ) : null}
+            </span>
+            <span>
+              <strong>Expiration:</strong> {cardDetails.exp_month}/{cardDetails.exp_year}
+            </span>
+          </div>
+        ) : null}
+        {cardLoading ? <p className="order-card-meta">Loading payment details…</p> : null}
+      </section>
+
+      {variant.showMessageActions ? (
+        <section className="order-section-card">
+          <h2 className="section-heading">Send Message</h2>
+          <p className="order-card-meta">Tap to notify the customer that you have arrived.</p>
+          <div className="action-grid">
+            <button type="button" className="action-button" onClick={handleSendMessage}>
+              Send Arrival Message
+            </button>
+            <button type="button" className="action-button" onClick={handleCall}>
+              Call Customer
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {variant.showFinalizeActions ? (
+        <section className="order-section-card">
+          <h2 className="section-heading">Finalize</h2>
+          <div className="action-grid">
+            <button type="button" className="action-button" onClick={finalizePlaceholder}>
+              Bypass
+            </button>
+            <button type="button" className="action-button" onClick={finalizePlaceholder}>
+              Verify Info
+            </button>
+            <button type="button" className="action-button" onClick={finalizePlaceholder}>
+              No Answer
+            </button>
+            <button type="button" className="action-button destructive" onClick={handleCancelOrder}>
+              Cancel Order
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      {variant.primaryActionLabel ? (
+        <div className="order-footer">
+          <button
+            type="button"
+            className="order-primary-action"
+            onClick={handlePrimaryAction}
+            disabled={actionLoading}
+          >
+            {variant.primaryActionLabel}
+          </button>
+          <p className="order-secondary-text">{formatName(order.owner)}</p>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/pages/orders/Orders.css
+++ b/src/pages/orders/Orders.css
@@ -1,0 +1,385 @@
+.orders-screen {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.orders-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.orders-toolbar h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.orders-toolbar .orders-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.orders-toolbar button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 0.45rem 0.9rem;
+  background: #ffffff;
+  font-size: 0.9rem;
+  color: #0a67c6;
+}
+
+.orders-toolbar button:hover {
+  border-color: rgba(10, 103, 198, 0.45);
+  background: rgba(148, 196, 255, 0.12);
+}
+
+.orders-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.order-section {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.order-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.order-section-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.order-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.order-card-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.order-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.order-card:first-child {
+  border-top: none;
+}
+
+.order-card-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-card-title {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.order-card-meta {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.85rem;
+}
+
+.notice {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.notice.success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #047857;
+}
+
+.notice.error {
+  background: rgba(190, 18, 60, 0.18);
+  color: #9f1239;
+}
+
+.notice.info {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.order-card-chevron {
+  color: #0a67c6;
+  font-size: 1.25rem;
+}
+
+.order-card.empty {
+  justify-content: center;
+  color: #4b5563;
+  padding: 1.25rem 0;
+}
+
+.order-card.empty p {
+  margin: 0;
+}
+
+.order-detail-screen {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.order-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.order-detail-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.order-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: #4b5563;
+  font-size: 0.85rem;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+}
+
+.status-pill.assigned {
+  background: rgba(249, 115, 22, 0.12);
+  color: #c2410c;
+}
+
+.status-pill.accepted {
+  background: rgba(34, 197, 94, 0.12);
+  color: #047857;
+}
+
+.status-pill.progress {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.order-section-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.product-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.product-thumb {
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  flex-shrink: 0;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #f8fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.product-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.product-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.product-quantity {
+  color: #1d4ed8;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.product-name {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.product-price {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4b5563;
+  font-style: italic;
+}
+
+.section-heading {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.detail-grid strong {
+  font-weight: 600;
+}
+
+.detail-note {
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.order-footer {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(241, 245, 249, 0.95);
+  padding: 1rem;
+  margin: 0 -1.25rem -1.25rem;
+}
+
+.order-primary-action {
+  width: 100%;
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #ffffff;
+  background: #111827;
+}
+
+.order-secondary-text {
+  margin: 0;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.75rem;
+}
+
+.action-button {
+  border: 1px solid #1d4ed8;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: #ffffff;
+  color: #1d4ed8;
+  font-weight: 600;
+  text-align: center;
+}
+
+.action-button.destructive {
+  color: #be123c;
+  border-color: rgba(190, 18, 60, 0.4);
+}
+
+.map-preview {
+  width: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #f8fafc;
+}
+
+.map-preview img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #be123c;
+  color: #ffffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+@media (min-width: 768px) {
+  .orders-toolbar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .order-footer {
+    position: static;
+    margin: 0;
+    background: transparent;
+    padding: 0;
+  }
+}

--- a/src/pages/orders/OrdersFeed.jsx
+++ b/src/pages/orders/OrdersFeed.jsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../context/AuthContext'
+import { fetchOrders } from '../../services/orderService'
+import './Orders.css'
+
+const SECTION_CONFIG = [
+  {
+    key: 'assigned',
+    status: 'Assigned',
+    title: 'Assigned Orders',
+    description: 'Orders that are ready for you to accept.',
+  },
+  {
+    key: 'accepted',
+    status: 'Accepted',
+    title: 'Accepted Orders',
+    description: 'Orders that are waiting to start delivery.',
+  },
+  {
+    key: 'progress',
+    status: 'In Progress',
+    title: 'Out for Delivery',
+    description: 'Orders that are currently on the way.',
+  },
+]
+
+function formatName(owner) {
+  if (!owner) {
+    return 'Unknown customer'
+  }
+
+  return [owner?.name?.first, owner?.name?.last].filter(Boolean).join(' ') || 'Unknown customer'
+}
+
+function formatAddress(address) {
+  if (!address) {
+    return 'No address on file'
+  }
+
+  const parts = []
+
+  if (address.apartment) {
+    parts.push(`Apt ${address.apartment}`)
+  }
+
+  if (address.description) {
+    parts.push(address.description)
+  }
+
+  return parts.join(', ') || 'No address on file'
+}
+
+function groupOrders(orders) {
+  return SECTION_CONFIG.map((section) => ({
+    ...section,
+    items: orders.filter((order) => order.status === section.status),
+  }))
+}
+
+export default function OrdersFeed() {
+  const { token } = useAuth()
+  const [orders, setOrders] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [lastUpdated, setLastUpdated] = useState(null)
+
+  const loadOrders = useCallback(async () => {
+    if (!token) {
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const data = await fetchOrders(token)
+      setOrders(Array.isArray(data) ? data : [])
+      setLastUpdated(new Date())
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to load orders.'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [token])
+
+  useEffect(() => {
+    loadOrders()
+  }, [loadOrders])
+
+  const sections = useMemo(() => groupOrders(orders), [orders])
+
+  if (loading && orders.length === 0) {
+    return (
+      <div className="screen">
+        <div className="spinner" aria-label="Loading orders" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="orders-screen">
+      <div className="orders-toolbar">
+        <div>
+          <h1>Orders</h1>
+          {lastUpdated ? (
+            <p className="order-card-meta">
+              Updated {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </p>
+          ) : null}
+        </div>
+        <div className="orders-actions">
+          <button type="button" onClick={loadOrders} disabled={loading}>
+            {loading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="form-error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="orders-list">
+        {sections.map((section) => (
+          <section className="order-section" key={section.key} aria-label={section.title}>
+            <div className="order-section-header">
+              <div>
+                <h2 className="order-section-title">{section.title}</h2>
+                <p className="order-card-meta">{section.description}</p>
+              </div>
+              <span className="order-section-count">{section.items.length}</span>
+            </div>
+            <div className="order-card-list">
+              {section.items.length === 0 ? (
+                <div className="order-card empty">
+                  <p>No orders in this stage.</p>
+                </div>
+              ) : (
+                section.items.map((order) => (
+                  <Link
+                    key={order._id}
+                    className="order-card"
+                    to={`/orders/${section.key}/${order._id}`}
+                    state={{ order }}
+                  >
+                    <div className="order-card-content">
+                      <p className="order-card-title">{formatName(order.owner)}</p>
+                      <p className="order-card-meta">{formatAddress(order.address)}</p>
+                    </div>
+                    <span className="order-card-chevron" aria-hidden="true">
+                      ➔
+                    </span>
+                  </Link>
+                ))
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -1,0 +1,147 @@
+import axios from 'axios'
+import urls from './urlServices'
+
+const client = axios.create({
+  baseURL: urls.api,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+
+function authHeaders(token) {
+  return token
+    ? {
+        Authorization: `Bearer ${token}`,
+      }
+    : {}
+}
+
+function parseError(error, fallbackMessage) {
+  if (error.response?.data?.message) {
+    return new Error(error.response.data.message)
+  }
+
+  if (error.response?.data?.error) {
+    return new Error(error.response.data.error)
+  }
+
+  return new Error(error.message || fallbackMessage)
+}
+
+export async function fetchOrders(token) {
+  try {
+    const response = await client.get('/drivers/orders', {
+      headers: authHeaders(token),
+    })
+
+    if (Array.isArray(response.data)) {
+      return response.data
+    }
+
+    if (Array.isArray(response.data?.orders)) {
+      return response.data.orders
+    }
+
+    return response.data?.data ?? []
+  } catch (error) {
+    throw parseError(error, 'Unable to load orders.')
+  }
+}
+
+export async function fetchOrderById(orderId, token) {
+  try {
+    const response = await client.get(`/drivers/orders/${orderId}`, {
+      headers: authHeaders(token),
+    })
+
+    return response.data?.order ?? response.data
+  } catch (error) {
+    if (error.response?.status === 404) {
+      const allOrders = await fetchOrders(token)
+      return allOrders.find((order) => order._id === orderId) ?? null
+    }
+
+    throw parseError(error, 'Unable to load order details.')
+  }
+}
+
+export async function updateOrder(updates, token) {
+  try {
+    const response = await client.patch(`/drivers/orders/${updates._id}`, updates, {
+      headers: authHeaders(token),
+    })
+
+    return response.data
+  } catch (error) {
+    if (error.response?.status && [404, 405].includes(error.response.status)) {
+      try {
+        const fallbackResponse = await client.post('/drivers/orders/update', updates, {
+          headers: authHeaders(token),
+        })
+
+        return fallbackResponse.data
+      } catch (fallbackError) {
+        throw parseError(fallbackError, 'Unable to update order.')
+      }
+    }
+
+    throw parseError(error, 'Unable to update order.')
+  }
+}
+
+export async function updateOrderStatus(orderId, status, token) {
+  return updateOrder(
+    {
+      _id: orderId,
+      status,
+    },
+    token,
+  )
+}
+
+export async function fetchCardUses(cardReference, token) {
+  if (!cardReference) {
+    return 0
+  }
+
+  try {
+    const response = await client.get(`/drivers/cards/${cardReference}/uses`, {
+      headers: authHeaders(token),
+    })
+
+    return response.data?.uses ?? response.data?.data ?? response.data ?? 0
+  } catch (error) {
+    throw parseError(error, 'Unable to fetch card usage information.')
+  }
+}
+
+export async function fetchCardDetails(stripeCustomerId, cardReference, token) {
+  if (!stripeCustomerId || !cardReference) {
+    return null
+  }
+
+  try {
+    const response = await client.get(
+      `/drivers/customers/${stripeCustomerId}/cards/${cardReference}`,
+      {
+        headers: authHeaders(token),
+      },
+    )
+
+    return response.data?.card ?? response.data
+  } catch (error) {
+    throw parseError(error, 'Unable to fetch card details.')
+  }
+}
+
+export async function sendArrivalMessage(payload, token) {
+  try {
+    const response = await client.post('/drivers/orders/send-arrival-message', payload, {
+      headers: authHeaders(token),
+    })
+
+    return response.data
+  } catch (error) {
+    throw parseError(error, 'Unable to send arrival message.')
+  }
+}


### PR DESCRIPTION
## Summary
- add a protected orders feed with grouped sections for assigned, accepted, and in-progress deliveries
- implement responsive order detail pages with payment insights, contact actions, and map previews
- introduce shared loader overlay styling and driver order API client utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42d80ce24832a8d13823751ce1fa4