### PR TITLE
Remove chat navigation option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import { Navigate, Outlet, Route, Routes } from 'react-router-dom'
 import LoginRoute from './routes/Login'
 import OrdersRoute from './routes/Orders/Index'
-import ChatThread from './routes/Chat/Thread'
 import ProfileRoute from './routes/Profile'
 import { ProtectedRoute } from './components/ProtectedRoute'
 import { Header } from './components/Header'
@@ -35,7 +34,6 @@ export default function App(): JSX.Element {
         <Route element={<AppShell />}>
           <Route index element={<Navigate to="/orders" replace />} />
           <Route path="/orders" element={<OrdersRoute />} />
-          <Route path="/chat" element={<ChatThread />} />
           <Route path="/profile" element={<ProfileRoute />} />
         </Route>
       </Route>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -9,12 +9,6 @@ export function BottomNav(): JSX.Element {
         </span>
         <span>Orders</span>
       </NavLink>
-      <NavLink to="/chat" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
-        <span role="img" aria-hidden>
-          💬
-        </span>
-        <span>Chat</span>
-      </NavLink>
       <NavLink to="/profile" className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}>
         <span role="img" aria-hidden>
           👤


### PR DESCRIPTION
## Summary
- remove the chat link from the bottom navigation so it no longer appears in the app chrome
- delete the chat route from the main router configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e49ae72f7083289a5ffda1031d4fe2