### PR TITLE
Remove On Delivery status toggle from profile

### DIFF
--- a/src/routes/Profile.tsx
+++ b/src/routes/Profile.tsx
@@ -52,14 +52,6 @@ export default function ProfileRoute(): JSX.Element {
           >
             Online
           </button>
-          <button
-            type="button"
-            className={`status-button ${driver?.status === 'ON_DELIVERY' ? 'active' : ''}`}
-            disabled={updating}
-            onClick={() => handleStatusChange('ON_DELIVERY')}
-          >
-            On Delivery
-          </button>
         </div>
         <p className="tracking-note">Location tracking: {trackingActive ? 'Active' : 'Paused'}</p>
       </section>


### PR DESCRIPTION
## Summary
- remove the On Delivery status button from the profile status selector so drivers can only toggle between Offline and Online

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e49ea76b248328aafaa6b4ebf0bc3f