### PR TITLE
Fix order status filtering

### DIFF
--- a/src/routes/Orders/Index.tsx
+++ b/src/routes/Orders/Index.tsx
@@ -5,6 +5,7 @@ import { OrderCard } from './OrderCard'
 import { OrderDetail } from './OrderDetail'
 import { Order } from '../../types'
 import { useToast } from '../../hooks/useToast'
+import { segmentOrders } from '../../utils/orderFilters'
 
 const tabConfig = [
   { id: 'pending', label: 'Pending' },
@@ -28,14 +29,7 @@ export default function OrdersRoute(): JSX.Element {
     }
   }, [orders, selected])
 
-  const segmented = useMemo(() => {
-    const pending = orders.filter((order) => order.status === 'NEW')
-    const active = orders.filter(
-      (order) => order.status === 'ASSIGNED' || order.status === 'IN_PROGRESS' || order.status === 'ARRIVED',
-    )
-    const completed = orders.filter((order) => order.status === 'COMPLETED')
-    return { pending, active, completed }
-  }, [orders])
+  const segmented = useMemo(() => segmentOrders(orders), [orders])
 
   const listForTab = useMemo(() => {
     if (activeTab === 'pending') return segmented.pending

--- a/src/routes/Orders/OrderCard.tsx
+++ b/src/routes/Orders/OrderCard.tsx
@@ -2,6 +2,7 @@ import { Order } from '../../types'
 import { formatCurrency, getInitials } from '../../utils/format'
 import { TimerChip } from '../../components/TimerChip'
 import { classNames } from '../../utils/classNames'
+import { isPendingOrder, normalizeOrderStatus } from '../../utils/orderFilters'
 
 interface OrderCardProps {
   order: Order
@@ -11,8 +12,9 @@ interface OrderCardProps {
 }
 
 export function OrderCard({ order, onAccept, onSelect, isSelected }: OrderCardProps): JSX.Element {
-  const isPending = order.status === 'NEW'
-  const statusLabel = order.status === 'COMPLETED' ? 'Completed' : undefined
+  const pending = isPendingOrder(order)
+  const normalizedStatus = normalizeOrderStatus(order.status)
+  const statusLabel = normalizedStatus === 'COMPLETED' ? 'Completed' : normalizedStatus === 'CANCELLED' ? 'Cancelled' : undefined
 
   return (
     <article
@@ -42,7 +44,7 @@ export function OrderCard({ order, onAccept, onSelect, isSelected }: OrderCardPr
         <span>Order Total</span>
         <span>{formatCurrency(order.total)}</span>
       </div>
-      {isPending && onAccept ? (
+      {pending && onAccept ? (
         <button
           type="button"
           className="action-btn accept-btn"

--- a/src/utils/orderFilters.ts
+++ b/src/utils/orderFilters.ts
@@ -1,0 +1,59 @@
+import { Order } from '../types'
+
+const pendingStatuses = new Set([
+  'NEW',
+  'PENDING',
+])
+
+const activeStatuses = new Set([
+  'ASSIGNED',
+  'ACCEPTED',
+  'IN_PROGRESS',
+  'ARRIVED',
+  'EN_ROUTE',
+  'OUT_FOR_DELIVERY',
+])
+
+const completedStatuses = new Set([
+  'COMPLETED',
+  'CANCELLED',
+  'DELIVERED',
+  'RETURNED',
+])
+
+export function normalizeOrderStatus(status: Order['status'] | string): string {
+  return String(status).trim().toUpperCase()
+}
+
+export function isPendingOrder(order: Order): boolean {
+  return pendingStatuses.has(normalizeOrderStatus(order.status))
+}
+
+export function isActiveOrder(order: Order): boolean {
+  const normalized = normalizeOrderStatus(order.status)
+  return activeStatuses.has(normalized) || (!pendingStatuses.has(normalized) && !completedStatuses.has(normalized))
+}
+
+export function isCompletedOrder(order: Order): boolean {
+  return completedStatuses.has(normalizeOrderStatus(order.status))
+}
+
+export function segmentOrders(orders: Order[]): {
+  pending: Order[]
+  active: Order[]
+  completed: Order[]
+} {
+  return orders.reduce(
+    (segments, order) => {
+      if (isPendingOrder(order)) {
+        segments.pending.push(order)
+      } else if (isCompletedOrder(order)) {
+        segments.completed.push(order)
+      } else {
+        segments.active.push(order)
+      }
+      return segments
+    },
+    { pending: [] as Order[], active: [] as Order[], completed: [] as Order[] },
+  )
+}


### PR DESCRIPTION
## Summary
- add utilities to normalize order statuses and group orders consistently
- update the orders list to use the shared segmentation helper for tab filters
- ensure order cards respect normalized statuses for pending actions and labels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4a322aa9c8328b1d91a3dd91886b3