### PR TITLE
Refine active orders filtering and layout

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -359,6 +359,13 @@ button {
   padding: 20px;
 }
 
+.active-orders {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+}
+
 .orders-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- filter active orders to only include deliveries assigned to the logged-in driver that are already in progress or arrived
- present active orders in a stacked detail list to match the updated design
- add styling to support the active orders list layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4a92cbe7c83289afa4404e11e00b3