### PR TITLE
Revise completed orders experience

### DIFF
--- a/src/routes/Orders/CompletedOrderCard.tsx
+++ b/src/routes/Orders/CompletedOrderCard.tsx
@@ -1,0 +1,56 @@
+import { Order } from '../../types'
+import { OrderDetail } from './OrderDetail'
+import { classNames } from '../../utils/classNames'
+import { formatTimeOfDay, getInitials } from '../../utils/format'
+
+interface CompletedOrderCardProps {
+  order: Order
+  expanded: boolean
+  onToggle: (order: Order) => void
+  onArrive: (orderId: string) => Promise<void>
+  onComplete: (orderId: string, signature: string) => Promise<void>
+}
+
+export function CompletedOrderCard({
+  order,
+  expanded,
+  onToggle,
+  onArrive,
+  onComplete,
+}: CompletedOrderCardProps): JSX.Element {
+  const deliveredTime = formatTimeOfDay(order.createdAt)
+
+  return (
+    <article className={classNames('completed-order-card', expanded && 'expanded')}>
+      <button
+        type="button"
+        className="completed-order-summary"
+        onClick={() => onToggle(order)}
+        aria-expanded={expanded}
+        aria-controls={`completed-order-${order.id}`}
+      >
+        <div className="summary-header">
+          <span className="order-number">Order #{order.number}</span>
+          <div className="summary-meta">
+            <span className="order-status-tag">Completed</span>
+            <span className="summary-caret" aria-hidden="true">
+              {expanded ? '▴' : '▾'}
+            </span>
+          </div>
+        </div>
+        <div className="summary-body">
+          <div className="customer-avatar">{getInitials(order.customer.name)}</div>
+          <div className="customer-details">
+            <h3>{order.customer.name}</h3>
+            <p>{deliveredTime ? `Delivered at ${deliveredTime}` : 'Completed order'}</p>
+          </div>
+        </div>
+      </button>
+      {expanded ? (
+        <div className="completed-order-detail" id={`completed-order-${order.id}`}>
+          <OrderDetail order={order} onArrive={onArrive} onComplete={onComplete} />
+        </div>
+      ) : null}
+    </article>
+  )
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -372,6 +372,134 @@ button {
   gap: 15px;
 }
 
+.completed-orders {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+}
+
+.completed-orders-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.completed-order-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.completed-order-summary {
+  background: white;
+  border: none;
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.completed-order-summary:focus {
+  outline: 2px solid #667eea;
+  outline-offset: 2px;
+}
+
+.completed-order-summary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(102, 126, 234, 0.2);
+}
+
+.completed-order-card.expanded .completed-order-summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.completed-order-summary .order-status-tag {
+  margin: 0;
+}
+
+.summary-caret {
+  font-size: 14px;
+  color: #6b7280;
+  transition: transform 0.2s ease;
+}
+
+.completed-order-card.expanded .summary-caret {
+  transform: rotate(180deg);
+}
+
+.summary-body {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.completed-order-summary .customer-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #ede9fe;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: #4c1d95;
+}
+
+.completed-order-summary .customer-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.completed-order-summary .customer-details h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.completed-order-summary .customer-details p {
+  margin: 4px 0 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.completed-order-detail .order-detail {
+  border-radius: 0 0 16px 16px;
+  box-shadow: none;
+  border: 1px solid #e5e7eb;
+  border-top: none;
+}
+
+.see-more-button {
+  align-self: center;
+  background: none;
+  border: none;
+  color: #667eea;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.see-more-button:hover {
+  text-decoration: underline;
+}
+
 .order-card {
   background: white;
   border-radius: 12px;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,3 +10,15 @@ export function getInitials(name: string): string {
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount)
 }
+
+export function formatTimeOfDay(dateString: string): string {
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date)
+}


### PR DESCRIPTION
## Summary
- limit completed orders to driver-assigned deliveries and show the most recent entries with a "See more" control
- present completed orders as collapsible summaries that expand to show full order details on demand
- add supporting time formatting utility and styles for the new completed order layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4abb47a988328bdf7e8c01db65f37