### PR TITLE
Revamp login page styling

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import '../styles/login.css'
 
 export default function LoginPage() {
   const navigate = useNavigate()
@@ -62,16 +63,21 @@ export default function LoginPage() {
   }
 
   return (
-    <main className="screen login-screen">
-      <section className="card login-card">
-        <header className="card-header">
-          <h1 className="card-title">Driver Login</h1>
-          <p className="card-subtitle">Sign in with your driver credentials to continue.</p>
+    <main className="login-page">
+      <section className="login-page__panel" aria-labelledby="login-heading">
+        <header className="login-page__header">
+          <div className="login-page__badge" aria-hidden="true">
+            <span role="img" aria-label="package">📦</span>
+          </div>
+          <h1 id="login-heading" className="login-page__title">
+            Jason's Delivery
+          </h1>
+          <p className="login-page__subtitle">Driver Portal</p>
         </header>
 
-        <form className="form" onSubmit={handleSubmit}>
-          <label className="form-field">
-            <span className="form-label">Email</span>
+        <form className="login-form" onSubmit={handleSubmit} noValidate>
+          <label className="login-form__field">
+            <span className="login-form__label">Email Address</span>
             <input
               type="email"
               name="email"
@@ -79,38 +85,45 @@ export default function LoginPage() {
               inputMode="email"
               value={email}
               onChange={handleEmailChange}
-              className="form-input"
-              placeholder="driver@email.com"
+              className="login-form__input"
+              placeholder="driver@example.com"
               disabled={authenticating}
               required
             />
           </label>
 
-          <label className="form-field">
-            <span className="form-label">Password</span>
+          <label className="login-form__field">
+            <span className="login-form__label">Password</span>
             <input
               type="password"
               name="password"
               autoComplete="current-password"
               value={password}
               onChange={handlePasswordChange}
-              className="form-input"
-              placeholder="Enter your password"
+              className="login-form__input"
+              placeholder="Min. 6 characters"
               disabled={authenticating}
               required
             />
           </label>
 
           {localError ? (
-            <p className="form-error" role="alert">
+            <p className="login-form__error" role="alert">
               {localError}
             </p>
           ) : null}
 
-          <button type="submit" className="form-button" disabled={authenticating}>
-            {authenticating ? 'Signing in…' : 'Sign in'}
+          <button type="submit" className="login-form__submit" disabled={authenticating}>
+            {authenticating ? 'Signing in…' : 'Sign In'}
           </button>
         </form>
+
+        <footer className="login-page__footer">
+          <p className="login-page__help-text">Need help accessing your account?</p>
+          <a className="login-page__support-link" href="mailto:support@jasonsdelivery.com">
+            Contact Support
+          </a>
+        </footer>
       </section>
     </main>
   )

--- a/src/styles/login.css
+++ b/src/styles/login.css
@@ -1,0 +1,192 @@
+.login-page {
+  min-height: 100vh;
+  margin: 0;
+  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(155deg, #6977ff 0%, #7964ff 35%, #9d58ff 70%, #c25cff 100%);
+  position: relative;
+  isolation: isolate;
+}
+
+.login-page::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.2), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.12), transparent 55%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.18), transparent 50%);
+  opacity: 0.9;
+  z-index: -1;
+}
+
+.login-page__panel {
+  width: min(100%, 28rem);
+  background: #ffffff;
+  border-radius: 2rem;
+  padding: clamp(2.25rem, 5vw, 3rem);
+  box-shadow: 0 35px 75px rgba(17, 24, 39, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 2.25rem;
+  position: relative;
+}
+
+.login-page__header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1rem;
+}
+
+.login-page__badge {
+  width: 80px;
+  height: 80px;
+  border-radius: 26px;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  background: linear-gradient(160deg, rgba(105, 119, 255, 0.9), rgba(156, 88, 255, 0.8));
+  color: #fff;
+  box-shadow: 0 18px 35px rgba(105, 119, 255, 0.4);
+}
+
+.login-page__badge span {
+  filter: drop-shadow(0 3px 6px rgba(17, 24, 39, 0.25));
+}
+
+.login-page__title {
+  margin: 0;
+  font-size: clamp(1.85rem, 3vw, 2.4rem);
+  font-weight: 700;
+  color: #111827;
+}
+
+.login-page__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.login-form__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.login-form__input {
+  border: 1.5px solid rgba(148, 163, 184, 0.7);
+  border-radius: 0.9rem;
+  padding: 0.9rem 1rem;
+  font-size: 1rem;
+  background: #f8fafc;
+  color: #0f172a;
+  transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.login-form__input::placeholder {
+  color: #94a3b8;
+}
+
+.login-form__input:focus {
+  outline: none;
+  border-color: #706bff;
+  background: #ffffff;
+  box-shadow: 0 0 0 4px rgba(112, 107, 255, 0.15);
+}
+
+.login-form__input:disabled {
+  background: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #64748b;
+}
+
+.login-form__error {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #e11d48;
+  background: rgba(248, 113, 113, 0.12);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+}
+
+.login-form__submit {
+  border: none;
+  border-radius: 999px;
+  padding: 0.95rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, #6366f1 0%, #8b5cf6 50%, #d946ef 100%);
+  color: #ffffff;
+  box-shadow: 0 18px 40px rgba(99, 102, 241, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.login-form__submit:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 50px rgba(99, 102, 241, 0.45);
+  filter: brightness(1.02);
+}
+
+.login-form__submit:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 14px 30px rgba(99, 102, 241, 0.35);
+}
+
+.login-form__submit:disabled {
+  opacity: 0.75;
+  cursor: wait;
+  box-shadow: none;
+}
+
+.login-page__footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.login-page__support-link {
+  color: #6366f1;
+  font-weight: 600;
+}
+
+.login-page__support-link:hover {
+  color: #4f46e5;
+}
+
+@media (max-width: 600px) {
+  .login-page__panel {
+    border-radius: 1.5rem;
+    padding: 2.25rem clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .login-page__badge {
+    width: 70px;
+    height: 70px;
+    border-radius: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the login page layout to include the hero badge, updated headings, and support footer to match the provided mock
- add a dedicated login stylesheet with gradient background, form control styling, and interactive button states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e59c292a9883288e1c53475566a51c